### PR TITLE
chore: Update CI workflow to restrict PRs to 'main' from 'dev' 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: ['main', 'master']
+    branches: ['main', 'dev']
   pull_request:
-    branches: ['main', 'master']
+    branches: ['main', 'dev']
 
 jobs:
   build:
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Check if PR into 'main' is from 'dev' branch
+        if: github.event.pull_request.base.ref == 'main'
+        run: |
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "Error: Pull requests to main must originate from the dev branch."
+            exit 1
+          fi
+        shell: bash
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request includes updates to the Node.js CI workflow to enforce stricter branch management and improve the CI process. The most important changes include modifying the branch triggers for the workflow and adding a check to ensure pull requests to the `main` branch originate from the `dev` branch.

Branch management improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL7-R9): Updated the branch triggers for the workflow to include only the `main` and `dev` branches instead of `main` and `master`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR25-R33): Added a step to check if pull requests to the `main` branch are originating from the `dev` branch, and to fail if they are not.