### PR TITLE
chore: Update CI workflow to restrict PRs to 'main' from 'dev'  (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Node.js CI
+name: Node CI
 
 on:
   push:
-    branches: ['main', 'master']
+    branches: ['main', 'dev']
   pull_request:
-    branches: ['main', 'master']
+    branches: ['main', 'dev']
 
 jobs:
   build:
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Check if PR into 'main' is from 'dev' branch
+        if: github.event.pull_request.base.ref == 'main'
+        run: |
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "Error: Pull requests to main must originate from the dev branch."
+            exit 1
+          fi
+        shell: bash
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
* chore: Update CI workflow to restrict PRs to 'main' from 'dev' branch only

* chore: Rename CI workflow from 'Node.js CI' to 'Node CI'